### PR TITLE
Feat/server login

### DIFF
--- a/appsettings.js
+++ b/appsettings.js
@@ -1,0 +1,12 @@
+Config = {
+  // @if NODE_ENV == 'DEVELOPMENT'
+  api: 'http://localhost:8080',
+  debug: true
+  // @endif
+  // @if NODE_ENV == 'TEST'
+  api: '',
+  // @endif
+  // @if NODE_ENV == 'PRODUCTION'
+  api: ''
+  // @endif
+}

--- a/client/www/ang/login/login.js
+++ b/client/www/ang/login/login.js
@@ -15,8 +15,7 @@ angular.module('app.login', [])
       store.set('refreshToken', refreshToken);
       $http({
         method: 'post',
-        url: Config.api + '/signin',
-        data: profile
+        url: Config.api + '/signin'
       })
       .then(function (response) {
         if (response.data.user) {

--- a/client/www/ang/login/login.js
+++ b/client/www/ang/login/login.js
@@ -1,6 +1,6 @@
 angular.module('app.login', [])
 
-.controller('loginCtrl', function($rootScope, $scope, store, $state, auth, $ionicHistory) {
+.controller('loginCtrl', function($rootScope, $scope, store, $state, auth, $ionicHistory, $http) {
   $scope.auth = auth;
   $scope.login = function () {
     auth.signin({
@@ -13,9 +13,22 @@ angular.module('app.login', [])
       store.set('fb_access_token', profile.identities[0].access_token);
       store.set('token', token);
       store.set('refreshToken', refreshToken);
-      $state.go('main');
+      $http({
+        method: 'post',
+        url: Config.api + '/signin',
+        data: profile
+      })
+      .then(function (response) {
+        if (response.data.user) {
+          $state.go('main');
+        } else {
+          $scope.logout();
+        }
+      })
+      .catch(function (error) {
+        $scope.logout();
+      }); 
     }, function (error) {
-      console.log(error);
     });
   };
 

--- a/client/www/index.html
+++ b/client/www/index.html
@@ -14,6 +14,8 @@
 
     <!-- compiled css output -->
     <link href="css/ionic.app.css" rel="stylesheet">
+
+    <script src="js/appsettings.js"></script>
     
     <!-- Auth0 Lock -->
     <script src="lib/auth0-lock/build/auth0-lock.js"></script>

--- a/client/www/js/appsettings.js
+++ b/client/www/js/appsettings.js
@@ -1,0 +1,4 @@
+Config = {
+  api: 'http://localhost:8080',
+  debug: true
+}

--- a/db/helpers.js
+++ b/db/helpers.js
@@ -1,3 +1,25 @@
 var db = require('./db.js');
 var models = require('./models.js');
 var Promise = require('bluebird');
+
+module.exports.findOrCreate = function (Model, attributes) {
+
+  return new Promise (function (resolve, reject) {
+    Model.forge(attributes).fetch()
+    .then(function (model) {
+      if (!model) {
+        model = new Model(attributes);
+      }
+      model.save()
+      .then(function () {
+        resolve(model);
+      })
+      .catch(function (error) {
+        reject(error);
+      });
+    })
+    .catch(function (error) {
+      reject(error);
+    });
+  });
+};

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,20 @@
+var path = require('path');
+var gulp = require('gulp');
+var preprocess = require('gulp-preprocess');
+gulp.task('dev', function() {
+  gulp.src(path.resolve('appsettings.js'))
+    .pipe(preprocess({context: { NODE_ENV: 'DEVELOPMENT', DEBUG: true}}))
+    .pipe(gulp.dest('client/www/js/'));
+});
+
+gulp.task('test_env', function() {
+  gulp.src(path.resolve('appsettings.js'))
+    .pipe(preprocess({context: { NODE_ENV: 'TEST', DEBUG: true}}))
+    .pipe(gulp.dest('client/www/js/'));
+});
+
+gulp.task('prod', function() {
+  gulp.src(path.resolve('appsettings.js'))
+    .pipe(preprocess({context: { NODE_ENV: 'PRODUCTION'}}))
+    .pipe(gulp.dest(path.resolve('client/www/js/')));
+});

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "mocha --reporter spec 'test/**/*.js'",
-    "start": "nodemon server/server.js",
+    "start": "gulp dev; nodemon server/server.js",
     "postinstall": "cd client; npm install; bower install"
   },
   "repository": {
@@ -36,6 +36,8 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
+    "gulp": "^3.9.1",
+    "gulp-preprocess": "^2.0.0",
     "mocha": "^2.4.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "bluebird": "^3.3.4",
     "body-parser": "^1.15.0",
     "bookshelf": "^0.9.2",
+    "cors": "^2.7.1",
     "express": "^4.13.4",
     "express-jwt": "^3.3.0",
     "jsonwebtoken": "^5.7.0",

--- a/server/routes.js
+++ b/server/routes.js
@@ -18,7 +18,7 @@ var jwtCheck = expressjwt({
   audience: process.env.AUTH_ID
 });
 
-var authRoutes = ['/users', '/profile', '/invites'];
+var authRoutes = ['/users', '/profile', '/invites', '/signin'];
 
 var routes = [
   {
@@ -45,7 +45,7 @@ var routes = [
   {
     path: '/signin',
     post: function (req, res) {
-      helpers.findOrCreate(models.User, {'facebook_id': req.body.identities[0].user_id})
+      helpers.findOrCreate(models.User, {'facebook_id': req.user.sub.split('|')[1]})
       .then( function (user) {
         console.log('sending');
         res.json({user: user});

--- a/server/routes.js
+++ b/server/routes.js
@@ -2,14 +2,17 @@ var path = require('path');
 var public = path.resolve('client/www');
 var url = require('url');
 var expressjwt = require('express-jwt');
+var helpers = require(path.resolve('db/helpers'));
+var models = require(path.resolve('db/models'));
 var jwt = require('jsonwebtoken');
 var env = require('node-env-file');
+
 
 // Reads in .env variables if available
 if (process.env.NODE_ENV !== 'production') {
   env(path.resolve('./.env'));
 }
-x
+
 var jwtCheck = expressjwt({
   secret: new Buffer(process.env.AUTH_SECRET, 'base64'),
   audience: process.env.AUTH_ID
@@ -37,6 +40,20 @@ var routes = [
         // user's total score from all games, total number of games played
         // list of friends, friend stats
 
+    }
+  },
+  {
+    path: '/signin',
+    post: function (req, res) {
+      helpers.findOrCreate(models.User, {'facebook_id': req.body.identities[0].user_id})
+      .then( function (user) {
+        console.log('sending');
+        res.json({user: user});
+      })
+      .catch(function (error) {
+        console.log('errored');
+        res.sendStatus(500);
+      });
     }
   },
   {

--- a/server/server.js
+++ b/server/server.js
@@ -1,6 +1,7 @@
 var express = require('express');
 var path = require('path');
 var db = require(path.resolve('db/db'));
+var cors = require('cors');
 var app = express();
 var server= require('http').Server(app);
 
@@ -10,6 +11,7 @@ var bodyParser = require('body-parser');
 var morgan = require('morgan');
 var io = require('./sockets.js');
 
+app.use(cors());
 app.use(bodyParser());
 app.use(morgan('dev'));
 


### PR DESCRIPTION
- new `Config` object available on client side to hold environment variables (for now, just need api url)
- `gulp dev` configures the above `Config` object correctly
- to make a call from `angular` to the server, use `$http` and a base url of `Config.api`
- add CORS middleware to server
- add `findOrCreate` helper for models
- set up server-side `signin` route, which now creates a new user based on facebook_id, if necessary