### PR TITLE
Basic server/client socket wiring for invites

### DIFF
--- a/client/www/ang/login/login.js
+++ b/client/www/ang/login/login.js
@@ -20,6 +20,10 @@ angular.module('app.login', [])
       })
       .then(function (response) {
         if (response.data.user) {
+          socket.emit('login', {
+            user_fb: store.get('profile').user_id.split('|')[1],
+            name: store.get('profile').name
+          });
           $state.go('main');
         } else {
           $scope.logout();
@@ -35,6 +39,7 @@ angular.module('app.login', [])
 
   $scope.logout = function () {
     auth.signout();
+    socket.emit('logout', store.get('profile').user_id.split('|')[1]);
     store.remove('profile');
     store.remove('token');
     store.remove('fb_access_token');

--- a/client/www/ang/main/main.js
+++ b/client/www/ang/main/main.js
@@ -36,6 +36,10 @@ angular.module('app.main', [])
       data: {invitation: invitation}
     })
     .then(function (response) {
+      socket.emit(acceptInvite, {
+        invitation: invitation,
+        name: store.get('profile').name
+      });
       console.log(response);
     })
     .catch(function (error) {
@@ -50,6 +54,10 @@ angular.module('app.main', [])
       data: {invitation: invitation}
     })
     .then(function (response) {
+      socket.emit(declineInvite, {
+        invitation: invitation,
+        name: store.get('profile').name
+      });
       console.log(response);
     })
     .catch(function (error) {

--- a/client/www/ang/newGame/newGame.js
+++ b/client/www/ang/newGame/newGame.js
@@ -51,6 +51,10 @@ angular.module('app.newGame', [])
     })
     .then(function (response){
       if (response.data.game) {
+        socket.emit('gameCreated', {
+          friends: $scope.inviting,
+          invitedBy: store.get('profile').name
+        });
         $state.go('game');
       } else {
         console.log('something went wrong');

--- a/client/www/index.html
+++ b/client/www/index.html
@@ -29,7 +29,13 @@
     <script src="lib/angular-jwt/dist/angular-jwt.js"></script>
     <script src="lib/angular-socket-io/socket.js"></script>
     <script src="lib/angular-facebook/lib/angular-facebook.js"></script>
+<<<<<<< HEAD
     <script src="lib/jquery/dist/jquery.min.js"></script>
+=======
+    
+    <script src="/socket.io/socket.io.js"></script>
+    <script>var socket = io();</script>
+>>>>>>> bd3d6c4... (feat) Add client emit for game created
 
     <script src="ang/app.js"></script>
     <script src="ang/routes.js"></script>

--- a/db/helpers.js
+++ b/db/helpers.js
@@ -1,6 +1,8 @@
 var db = require('./db.js');
 var models = require('./models.js');
 var Promise = require('bluebird');
+var events = require('events');
+var eventEmitter = new events.EventEmitter();
 
 module.exports.findOrCreate = function (Model, attributes) {
 
@@ -119,3 +121,5 @@ module.exports.getInvites = function (user_fb) {
     });
   });
 };
+
+module.exports.eventEmitter = eventEmitter;

--- a/server/sockets.js
+++ b/server/sockets.js
@@ -1,7 +1,61 @@
+var helpers = require('../db/helpers');
+
+var online = {};
+
 module.exports = function(server){
+  //TODO:1 - ON DC AND RECONNECTION ADD TO ONLINE FROM MAIN CLIENT PAGE
   var io = require('socket.io')(server);
 
-  io.on('connection', function() {
+  io.on('connection', function (socket) {
     console.log('Socket to me');
+
+    //TODO:1 - socket emit checkAuth to add a user that goes straight to main page
+
+    socket.on('login', function (userInfo) {
+      online[userInfo.user_fb] = {
+        socket_id: socket.id,
+        user_fb: userInfo.user_fb,
+        name: userInfo.name,
+        loginTime: new Date()
+      }
+    });
+
+    socket.on('gameCreated', function (gameInfo) {
+      for(var friend in gameInfo.friends) {
+        if (online[friend]) {
+          io.to(online[friend].socket_id).emit('invite', gameInfo.invitedBy);
+        }
+      }
+    });
+
+    socket.on('acceptInvite', function (invitationInfo) {
+      if (online[invitationInfo.invitation.creator.facebook_id]) {
+        io.to(online[invitationInfo.invitation.creator.facebook_id].socket_id).emit('inviteAccepted');
+      }
+    });
+
+    socket.on('declineInvite', function (invitationInfo) {
+      if (online[invitationInfo.invitation.creator.facebook_id]) {
+        io.to(online[invitationInfo.invitation.creator.facebook_id].socket_id).emit('inviteDeclined');
+      }
+    });
+
+    socket.on('logout', function (user_fb) {
+      if (online[user_fb]) {
+        console.log('BEFORE LOGOUT', online);
+        delete online[user_fb];
+        console.log('AFTER LOGOUT', online);
+      }
+    });
+
+    socket.on('disconnect', function () {
+      console.log('BEFORE DC', online);
+      for (var connection in online) {
+        if (online[connection].socket_id === socket.id) {
+          delete online[connection];
+        }
+      }
+      console.log('AFTER DC', online);
+    });
   });
 }


### PR DESCRIPTION
(feat) Add client emit for game created
(feat) Add server listener for game created that invites
(feat) Add client emit and server listener for invitations

- Client side event emitters on login, logout, new game, accept/decline invite
- Server side listeners manage who is online
- Server side emitters will send invites events to all but creator on new game
- Server side emitters will sent accept/decline events to game creator

***KNOWN BUG*** If socket is closed via leaving/closing app, upon returning and going directly to main page the client will not be stored as online.  Will fix when implementing client side listeners.