### PR TITLE
(fix) do not enable slide back for game view (resolves #207)

### DIFF
--- a/client/www/ang/game/game.html
+++ b/client/www/ang/game/game.html
@@ -1,4 +1,4 @@
-<ion-view title="Game" hide-back-button="true">
+<ion-view title="Game" can-swipe-back="false" hide-back-button="true">
   <ion-nav-buttons side="left">
     <button ng-click="back()" class="button buttons header-item">
         <i class="icon ion-ios-arrow-back"></i>


### PR DESCRIPTION
- previously, you could swipe back to the new game view from the game view. this is now disabled, and users have to use the back button