### PR TITLE
Feat/end game - resolve #231 & (feat) Limit topic/response length to avoid DB errors resolve #266

### DIFF
--- a/client/www/ang/directives.js
+++ b/client/www/ang/directives.js
@@ -34,5 +34,18 @@ angular.module('app.directives', [])
       });
     }
   };
-}]);
+}])
 
+.directive('endGame', function (socket) {
+  return {
+    restrict: 'E',
+    template: '<button ng-disabled="!Game.started" ng-if="Game.isCreator" class="button button-block button-assertive">End Game</button>',
+    link: function (scope, element, attrs) {
+      element.on('click', function () {
+        if (scope.Game) {
+          socket.emit('endGame', scope.Game.game.id);
+        }
+      });
+    }
+  }
+});

--- a/client/www/ang/directives.js
+++ b/client/www/ang/directives.js
@@ -36,7 +36,7 @@ angular.module('app.directives', [])
   };
 }])
 
-.directive('endGame', function (socket) {
+.directive('endGame', function (socket, $state) {
   return {
     restrict: 'E',
     template: '<button ng-disabled="!Game.started" ng-if="Game.isCreator" class="button button-block button-assertive">End Game</button>',
@@ -44,6 +44,7 @@ angular.module('app.directives', [])
       element.on('click', function () {
         if (scope.Game) {
           socket.emit('endGame', scope.Game.game.id);
+          $state.go('main');
         }
       });
     }

--- a/client/www/ang/game/game.html
+++ b/client/www/ang/game/game.html
@@ -134,6 +134,6 @@
         </ion-content>
       </ul>
     </div>
-
+    <end-game></end-game>
   </ion-content>
 </ion-view>

--- a/client/www/ang/game/game.js
+++ b/client/www/ang/game/game.js
@@ -9,7 +9,9 @@ angular.module('app.game', [])
   $ionicPopup,
   $ionicScrollDelegate,
   $ionicPlatform,
-  socket
+  socket,
+  $timeout,
+  ionicToast
 ) {
 
   angular.extend($scope, Game);
@@ -146,5 +148,18 @@ angular.module('app.game', [])
     $ionicScrollDelegate.scrollTop(true);
   });
 
+  $scope.$watch('Game.response', function() {
+    if (Game.response.length > 255) {
+      Game.response = Game.response.substring(0, 255);
+      ionicToast.show('Max response length', 'top', false, 2500);
+    }
+  });
+
+  $scope.$watch('Game.topic', function() {
+    if (Game.topic.length > 255) {
+      Game.topic = Game.topic.substring(0, 255);
+      ionicToast.show('Max response length', 'top', false, 2500);
+    }
+  });
 
 });

--- a/client/www/ang/game/game.js
+++ b/client/www/ang/game/game.js
@@ -138,8 +138,6 @@ angular.module('app.game', [])
     }
   });
 
-
-
   $ionicPlatform.on('resume', function () {
     Game.updateGame();
   });

--- a/client/www/ang/services.js
+++ b/client/www/ang/services.js
@@ -1,13 +1,14 @@
 angular.module('app.services', [])
 
-.factory('Game', ['$q', '$http', 'store', 'socket', '$timeout', 'ionicToast', '$rootScope', function(
+.factory('Game', ['$q', '$http', 'store', 'socket', '$timeout', 'ionicToast', '$rootScope', '$state', function(
   $q,
   $http,
   store,
   socket,
   $timeout,
   ionicToast,
-  $rootScope){
+  $rootScope,
+  $state){
 
   var obj = {
     submitting: false,
@@ -500,6 +501,11 @@ angular.module('app.services', [])
         break;
       }
     }
+  });
+
+  socket.on('endGame', function () {
+    ionicToast.show('Creator has ended the game, goodbye!', 'top', false, 4000);
+    $state.go('main');
   });
 
   return obj;

--- a/db/helpers.js
+++ b/db/helpers.js
@@ -721,3 +721,9 @@ module.exports.getProfile = function (user_id) {
     })
   });
 };
+
+module.exports.endGame = function (game_id) {
+  models.Game.forge({id: game_id})
+  .fetch()
+  .then(module.exports.winGame);
+};

--- a/server/sockets.js
+++ b/server/sockets.js
@@ -54,7 +54,8 @@ module.exports.init = function(server){
     });
 
     socket.on('endGame', function (game_id) {
-      console.log(game_id)
+      helpers.endGame(game_id);
+      socket.broadcast.to('game:' + game_id).emit('endGame');
     });
 
     var markConnected = function (userInfo) {

--- a/server/sockets.js
+++ b/server/sockets.js
@@ -53,6 +53,10 @@ module.exports.init = function(server){
       socket.join('game:' + game_id);
     });
 
+    socket.on('endGame', function (game_id) {
+      console.log(game_id)
+    });
+
     var markConnected = function (userInfo) {
       if (!online[userInfo.id]) {
         online[userInfo.id] = [];


### PR DESCRIPTION
Places big red button on bottom of game-creator's screen.  Can only end after started.  Server/db processes game as 'won' with an undefined winner.  Users are 'redirected' to the main state, with all but creator receiving a toast informing them that creator has terminated game.