### PR TITLE
(fix) Option display only if reader and no topic

### DIFF
--- a/client/www/ang/directives.js
+++ b/client/www/ang/directives.js
@@ -74,8 +74,10 @@ angular.module('app.directives', [])
       scope.$watch('Game.game.current_round', function() {
         if (scope.Game.game.current_round && scope.Game.game.current_round.reader_id === scope.Game.remote_id ) {
           scope.$watch('Game.game.current_round.reader_id', function () {
-            if (!scope.Game.game.completed && !scope.Game.game.current_round.topic.length) {
+            if (!scope.Game.game.completed && scope.Game.game.current_round.reader_id === scope.Game.remote_id && !scope.Game.game.current_round.topic.length) {
               $(elem).show();
+            } else {
+              $(elem).hide();
             }
           });
           scope.$watch('Game.game.current_round.topic', function () {


### PR DESCRIPTION
Added an else inside the Game.game.current_round.reader_id watch that will hide if reader_id changes and is no longer === remote_id