### PR TITLE
(fix) put notification sending into a try/catch block to suppress errors (resolves #360)

### DIFF
--- a/server/push.js
+++ b/server/push.js
@@ -37,28 +37,34 @@ var sendToUser = function (user_id, text) {
     devices.models.forEach(function (device) {
       var token = device.get('device_token');
 
-      //iOS
-      var apnDevice = new apn.Device(token);
-      var note = new apn.Notification();
-      note.expiry = Math.floor(Date.now() / 1000) + 3600;
-      note.sound = sound;
-      note.alert = text;
-      apnConnection.pushNotification(note, apnDevice);
+      try {
+        //iOS
+        var apnDevice = new apn.Device(token);
+        var note = new apn.Notification();
+        note.expiry = Math.floor(Date.now() / 1000) + 3600;
+        note.sound = sound;
+        note.alert = text;
+        apnConnection.pushNotification(note, apnDevice);
 
-      //Android
-      var message = new gcm.Message({
-        priority: 'high',
-        contentAvailable: true,
-        delayWhileIdle: true,
-        timeToLive: 3,
-        notification: {
-          title: text,
-          body: 'Black Mamba'
-        }
-      });
-      var regTokens = [token];
-      var sender = new gcm.Sender(process.env.GCM_API_KEY);
-      sender.send(message, {registrationTokens: regTokens});
+        //Android
+        var message = new gcm.Message({
+          priority: 'high',
+          contentAvailable: true,
+          delayWhileIdle: true,
+          timeToLive: 3,
+          notification: {
+            title: text,
+            body: 'Black Mamba'
+          }
+        });
+        var regTokens = [token];
+        var sender = new gcm.Sender(process.env.GCM_API_KEY);
+        sender.send(message, {registrationTokens: regTokens});
+      }
+      // okay to fail silently here. this just means we passed in an Android device token to the apn library
+      catch (error) {
+        
+      }
 
     });
   });


### PR DESCRIPTION
- this code throws errors because we take any device token, whether it be from an android or ios device, and attempt to send a push notification to it through both iOS and Android push notifications, so that we do not have to worry about identifying the OS on the server side. The apn library we are using throws errors if it gets an invalid device token; this is okay, we now simply wrap the error in a try/catch