### PR TITLE
(fix) only run responsiveVoice on ionic serve

### DIFF
--- a/client/www/ang/services.js
+++ b/client/www/ang/services.js
@@ -627,7 +627,7 @@ angular.module('app.services', ['ionic'])
 })
 
 .factory('Voice', function ($ionicPlatform) {
-  if ($ionicPlatform.is('ios') || !window.cordova) {
+  if (!window.cordova) {
     return {
       speak: function (text, voice, onend) {
         responsiveVoice.speak(text, voice, {
@@ -636,11 +636,16 @@ angular.module('app.services', ['ionic'])
       }
     }
   } else {
+    var rate = 1.0;
+    if ($ionicPlatform.is('ios')) {
+      rate = 1.60;
+    }
     return {
       speak: function (text, voice, onend) {
         TTS.speak({
             text: text,
             locale: 'en-GB',
+            rate: rate
           }, function () {
             onend();
           }


### PR DESCRIPTION
- use cordova TTS on all platforms but ionic serve
- adjust speech rate for ios vs. android