### PR TITLE
Resolves Auth0 migration

### DIFF
--- a/client/www/ang/login/login.js
+++ b/client/www/ang/login/login.js
@@ -54,8 +54,6 @@ angular.module('app.login', [])
     store.set('profile', profile);
     store.set('token', token);
     store.set('refreshToken', refreshToken);
-    store.set('fb_access_token', profile.identities[0].access_token);
-    // console.log('***fb_access_token***', store.get('fb_access_token'));
     $http({
       method: 'post',
       url: Config.api + '/signin',
@@ -68,17 +66,20 @@ angular.module('app.login', [])
     })
     .then(function (response) {
       if (response.data.user) {
-        // store.set('fb_access_token', response.data.fb_access_token)
-        store.set('games_won', response.data.games.won);
-        store.set('games_played', response.data.games.played);
-        store.set('created_at', response.data.user.created_at);
-        store.set('remote_id', response.data.user.id);
-        store.set('current_game_id', response.data.user.current_game_id);
+        var user = response.data.user;
+        var games = response.data.games;
+        var fb_access_token = response.data.fb_access_token;
+        store.set('fb_access_token', fb_access_token);
+        store.set('games_won', games.won);
+        store.set('games_played', games.played);
+        store.set('created_at', user.created_at);
+        store.set('remote_id', user.id);
+        store.set('current_game_id', user.current_game_id);
         setProfile();
-        Game.game.id = response.data.user.current_game_id;
+        Game.game.id = user.current_game_id;
         Game.getGame();
         socket.emit('login', {
-          id: response.data.user.id
+          id: user.id
         });
         $state.go('main');
       } else {
@@ -88,10 +89,6 @@ angular.module('app.login', [])
     .catch(function (error) {
       $scope.logout();
     });
-
-    function setAndPost() {
-
-    }
   };
 
   function handleFailedSignin(error) {

--- a/client/www/ang/login/login.js
+++ b/client/www/ang/login/login.js
@@ -14,48 +14,17 @@ angular.module('app.login', [])
   Facebook
 ) {
 
+  var params = {
+    authParams: {
+      scope: 'openid offline_access',
+      device: 'Mobile device'
+    }
+  };
+
   $scope.auth = auth;
 
   $scope.login = function () {
-    auth.signin({
-      authParams: {
-        scope: 'openid offline_access',
-        device: 'Mobile device'
-      },
-    }, function (profile, token, accessToken, state, refreshToken) {
-      store.set('profile', profile);
-      store.set('fb_access_token', profile.identities[0].access_token);
-      store.set('token', token);
-      store.set('refreshToken', refreshToken);
-      $http({
-        method: 'post',
-        url: Config.api + '/signin',
-        data: {name: profile.name, pic_url: profile.picture, device_token: store.get('device_token')}
-      })
-      .then(function (response) {
-        if (response.data.user) {
-          store.set('games_won', response.data.games.won);
-          store.set('games_played', response.data.games.played);
-          store.set('created_at', response.data.user.created_at);
-          store.set('remote_id', response.data.user.id);
-          store.set('current_game_id', response.data.user.current_game_id);
-          setProfile();
-          Game.game.id = response.data.user.current_game_id;
-          Game.getGame();
-          socket.emit('login', {
-            id: response.data.user.id
-          });
-          $state.go('main');
-        } else {
-          $scope.logout();
-        }
-      })
-      .catch(function (error) {
-        $scope.logout();
-      });
-    }, function (error) {
-      $scope.logout();
-    });
+    auth.signin(params, handleUser, handleFailedSignin);
   };
 
   $scope.logout = function () {
@@ -66,50 +35,6 @@ angular.module('app.login', [])
 
   $scope.iOS = function () {
     return ionic.Platform.isIOS();
-  };
-
-  var getProfilePic = function () {
-    var facebookId = store.get('profile').user_id.split('|')[1];
-    var query = '/' + facebookId + '/picture?access_token=' + store.get('fb_access_token') + '&type=normal';
-    return Facebook.api(query, function (response) {
-        if (response.error) {
-          console.log('Facebook API error: ', response.error);
-          return;
-        }
-        store.set('pic_url', response.data.url);
-      }
-    );
-  };
-
-  var setProfile = function () {
-    getProfilePic().then(function() {
-      $scope.profile = {
-        name: store.get('profile').name,
-        picUrl: store.get('pic_url'),
-        gamesWon: store.get('games_won'),
-        gamesPlayed: store.get('games_played'),
-        createdAt: store.get('created_at')
-      };
-    });
-  };
-
-  var clearProfile = function () {
-    $scope.profile = {
-      name: '',
-      picUrl: '',
-      gamesPlayed: '',
-      createdAt: ''
-    };
-  };
-
-  var establish = function () {
-    socket.emit('establish', {
-      id: store.get('remote_id')
-    });
-    var game_id = store.get('current_game_id');
-    if (game_id) {
-      socket.emit('room', game_id);
-    }
   };
 
   if (auth.isAuthenticated) {
@@ -123,5 +48,98 @@ angular.module('app.login', [])
     });
     $state.go('main');
   }
+
+  function handleUser (profile, token, accessToken, state, refreshToken) {
+    var facebookId = profile.user_id.split('|')[1];
+    store.set('profile', profile);
+    store.set('token', token);
+    store.set('refreshToken', refreshToken);
+    store.set('fb_access_token', profile.identities[0].access_token);
+    // console.log('***fb_access_token***', store.get('fb_access_token'));
+    $http({
+      method: 'post',
+      url: Config.api + '/signin',
+      data: {
+        name: profile.name,
+        pic_url: profile.picture,
+        facebookId: facebookId,
+        device_token: store.get('device_token')
+      }
+    })
+    .then(function (response) {
+      if (response.data.user) {
+        // store.set('fb_access_token', response.data.fb_access_token)
+        store.set('games_won', response.data.games.won);
+        store.set('games_played', response.data.games.played);
+        store.set('created_at', response.data.user.created_at);
+        store.set('remote_id', response.data.user.id);
+        store.set('current_game_id', response.data.user.current_game_id);
+        setProfile();
+        Game.game.id = response.data.user.current_game_id;
+        Game.getGame();
+        socket.emit('login', {
+          id: response.data.user.id
+        });
+        $state.go('main');
+      } else {
+        $scope.logout();
+      }
+    })
+    .catch(function (error) {
+      $scope.logout();
+    });
+
+    function setAndPost() {
+
+    }
+  };
+
+  function handleFailedSignin(error) {
+    $scope.logout();
+  }
+
+  function getProfilePic() {
+    var facebookId = store.get('profile').user_id.split('|')[1];
+    var query = '/' + facebookId + '/picture?access_token=' + store.get('fb_access_token') + '&type=normal';
+    return Facebook.api(query, function (response) {
+        if (response.error) {
+          console.log('Facebook API error: ', response.error);
+          return;
+        }
+        store.set('pic_url', response.data.url);
+      }
+    );
+  };
+
+  function setProfile() {
+    getProfilePic().then(function() {
+      $scope.profile = {
+        name: store.get('profile').name,
+        picUrl: store.get('pic_url'),
+        gamesWon: store.get('games_won'),
+        gamesPlayed: store.get('games_played'),
+        createdAt: store.get('created_at')
+      };
+    });
+  };
+
+  function clearProfile() {
+    $scope.profile = {
+      name: '',
+      picUrl: '',
+      gamesPlayed: '',
+      createdAt: ''
+    };
+  };
+
+  function establish() {
+    socket.emit('establish', {
+      id: store.get('remote_id')
+    });
+    var game_id = store.get('current_game_id');
+    if (game_id) {
+      socket.emit('room', game_id);
+    }
+  };
 
 });

--- a/server/facebook.js
+++ b/server/facebook.js
@@ -1,0 +1,72 @@
+var path = require('path');
+var request = require('request');
+var env = require('node-env-file');
+
+if (process.env.NODE_ENV !== 'production') {
+  env(path.resolve('.env'));
+}
+
+var client_id = process.env.AUTH0_MGMT_API_ID;
+var client_secret = process.env.AUTH0_MGMT_API_SECRET;
+
+function getFBAccessToken(userId) {
+
+  return authenticateAuth0MgmtClient()
+    .then(extractAccessToken)
+    .then(getFBProfile)
+    .then(extractFBToken)
+    .catch(handleError);
+
+  function handleError(error) {
+    console.log('fb.js error', error)
+  }
+
+  function extractFBToken(body) {
+    var identities = parseReply(body, 'identities');
+    return identities[0].access_token;
+  }
+
+  function extractAccessToken(body) {
+    return parseReply(body, 'access_token');
+  }
+
+  function parseReply(str, prop) {
+    var obj = JSON.parse(str);
+    if (prop !== undefined) return obj[prop];
+    return obj;
+  }
+
+  function getFBProfile(auth0MgmtToken) {
+    return new Promise(function(resolve, reject) {
+      var options = {
+        method: 'GET',
+        url: 'https://purplecobras.auth0.com/api/v2/users/' + userId,
+        headers: {
+          'content-type': 'application/json',
+          'authorization': 'Bearer ' + auth0MgmtToken
+        }
+      };
+      request(options, function (error, response, body) {
+        if (error) reject(error);
+        resolve(body);
+      });
+    });
+  }
+
+  function authenticateAuth0MgmtClient() {
+    return new Promise(function(resolve, reject) {
+      var options = {
+        method: 'POST',
+        url: 'https://purplecobras.auth0.com/oauth/token',
+        headers: { 'content-type': 'application/json' },
+        body: '{"client_id":"' + client_id + '","client_secret":"' + client_secret + '","audience":"https://purplecobras.auth0.com/api/v2/","grant_type":"client_credentials"}'
+      };
+      request(options, function (error, response, body) {
+        if (error) reject(error);
+        resolve(body);
+      });
+    });
+  }
+}
+
+module.exports = getFBAccessToken;

--- a/server/facebook.js
+++ b/server/facebook.js
@@ -11,29 +11,25 @@ var client_secret = process.env.AUTH0_MGMT_API_SECRET;
 
 function getFBAccessToken(userId) {
 
-  return authenticateAuth0MgmtClient()
-    .then(extractAccessToken)
+  return authenticateBackendClient()
+    .then(extractAuth0Token)
     .then(getFBProfile)
     .then(extractFBToken)
     .catch(handleError);
 
-  function handleError(error) {
-    console.log('fb.js error', error)
-  }
-
-  function extractFBToken(body) {
-    var identities = parseReply(body, 'identities');
-    return identities[0].access_token;
-  }
-
-  function extractAccessToken(body) {
-    return parseReply(body, 'access_token');
-  }
-
-  function parseReply(str, prop) {
-    var obj = JSON.parse(str);
-    if (prop !== undefined) return obj[prop];
-    return obj;
+  function authenticateBackendClient() {
+    return new Promise(function(resolve, reject) {
+      var options = {
+        method: 'POST',
+        url: 'https://purplecobras.auth0.com/oauth/token',
+        headers: { 'content-type': 'application/json' },
+        body: '{"client_id":"' + client_id + '","client_secret":"' + client_secret + '","audience":"https://purplecobras.auth0.com/api/v2/","grant_type":"client_credentials"}'
+      };
+      request(options, function (error, response, body) {
+        if (error) reject(error);
+        resolve(body);
+      });
+    });
   }
 
   function getFBProfile(auth0MgmtToken) {
@@ -53,19 +49,23 @@ function getFBAccessToken(userId) {
     });
   }
 
-  function authenticateAuth0MgmtClient() {
-    return new Promise(function(resolve, reject) {
-      var options = {
-        method: 'POST',
-        url: 'https://purplecobras.auth0.com/oauth/token',
-        headers: { 'content-type': 'application/json' },
-        body: '{"client_id":"' + client_id + '","client_secret":"' + client_secret + '","audience":"https://purplecobras.auth0.com/api/v2/","grant_type":"client_credentials"}'
-      };
-      request(options, function (error, response, body) {
-        if (error) reject(error);
-        resolve(body);
-      });
-    });
+  function extractAuth0Token(body) {
+    return parseReply(body, 'access_token');
+  }
+
+  function extractFBToken(body) {
+    var identities = parseReply(body, 'identities');
+    return identities[0].access_token;
+  }
+
+  function parseReply(str, prop) {
+    var obj = JSON.parse(str);
+    if (prop !== undefined) return obj[prop];
+    return obj;
+  }
+
+  function handleError(error) {
+    console.log('fb.js error', error)
   }
 }
 

--- a/server/routes.js
+++ b/server/routes.js
@@ -60,14 +60,14 @@ var routes = [
         user.set('full_name', req.body.name)
         .set('pic_url', req.body.pic_url).save()
         .then(function updateDeviceAndRespond(user) {
-
           helpers.getProfile(user.id)
             .then(function (games) {
               if (req.body.device_token) {
                 helpers.updateDevice(user.get('id'), req.body.device_token)
                 .then(respond);
+              } else {
+                respond();
               }
-              respond();
 
               function respond() {
                 getFBAccessToken(userId)
@@ -77,7 +77,6 @@ var routes = [
                 .catch(function(error) {
                   console.log('getFBAccessToken err', error);
                 });
-
               }
             });
         });

--- a/server/routes.js
+++ b/server/routes.js
@@ -6,7 +6,7 @@ var helpers = require(path.resolve('db/helpers'));
 var models = require(path.resolve('db/models'));
 var jwt = require('jsonwebtoken');
 var env = require('node-env-file');
-
+var getFBAccessToken = require(path.resolve('server/facebook'));
 
 // Reads in .env variables if available
 if (process.env.NODE_ENV !== 'production') {
@@ -38,12 +38,6 @@ var routes = [
     }
   },
   {
-    path: '/users',
-    post: function (req, res) {
-      // Store new user data in db.
-    },
-  },
-  {
     path: '/users/:id',
     get: function (req, res) {
       helpers.findOrCreate(models.User, {'id': req.params.id})
@@ -57,31 +51,33 @@ var routes = [
     }
   },
   {
-    path: '/profile',
-    get: function (req, res) {
-      // Query db for data we'd display on a profile
-        // user's total score from all games, total number of games played
-        // list of friends, friend stats
-
-    }
-  },
-  {
     path: '/signin',
     post: function (req, res) {
-      helpers.findOrCreate(models.User, {'facebook_id': req.user.sub.split('|')[1]})
-      .then( function (user) {
+      var userId = req.user.sub;
+      var facebookId = userId.split('|')[1];
+      helpers.findOrCreate(models.User, {'facebook_id': facebookId})
+      .then(function saveNameAndPic(user) {
         user.set('full_name', req.body.name)
         .set('pic_url', req.body.pic_url).save()
-        .then(function (user) {
+        .then(function updateDeviceAndRespond(user) {
+
           helpers.getProfile(user.id)
             .then(function (games) {
               if (req.body.device_token) {
                 helpers.updateDevice(user.get('id'), req.body.device_token)
-                .then(function () {
-                  res.json({user: user, games: games});
+                .then(respond);
+              }
+              respond();
+
+              function respond() {
+                getFBAccessToken(userId)
+                .then(function(fbAccessToken) {
+                  res.json({ user: user, games: games, fb_access_token: fbAccessToken });
+                })
+                .catch(function(error) {
+                  console.log('getFBAccessToken err', error);
                 });
-              } else {
-                res.json({user: user, games: games});
+
               }
             });
         });


### PR DESCRIPTION
#### Background

https://auth0.com/docs/migrations

> The format of the user profile JSON object (id_token) that is returned by Auth0 Authentication APIs has been changed to remove the Identity Provider's access token, which had been included in the user profile identities array.
> 
> Now, to obtain a user's IdP access token, you will need to make an HTTP GET call to the /api/v2/users/{user-id} endpoint containing an API token generated with read:user_idp_tokens scope.
#### Resolution

Created `getFBAccessToken` function to send HTTP GET call to Auth0 endpoint and obtain the FB profile containing the FB access token. This resolves the Auth0 breaking change.
#### Important Note

Deployment and dev environment variables will need to be updated with `AUTH0_MGMT_API_ID` and `AUTH0_MGMT_API_SECRET` properties.
